### PR TITLE
Export kml de la porte, bugfixes

### DIFF
--- a/src/main/java/com/apogee/dev/CUJaS/Core/Melissa/MelissaParser.java
+++ b/src/main/java/com/apogee/dev/CUJaS/Core/Melissa/MelissaParser.java
@@ -227,9 +227,9 @@ public class MelissaParser implements XMLParser {
         left.add(corridor.start_point);
         right.add(0, corridor.end_point);
 
-        this.figures.add(new Line(left));
+        this.figures.add(new Line(left, "corr_line_left"));
         logger.debug("Left line built: " + this.figures.get(this.figures.size() - 1));
-        this.figures.add(new Line(right));
+        this.figures.add(new Line(right, "corr_line_right"));
         logger.debug("Right line built: " + this.figures.get(this.figures.size() - 1));
     }
 

--- a/src/main/java/com/apogee/dev/CUJaS/SITACObjects/Corridor.java
+++ b/src/main/java/com/apogee/dev/CUJaS/SITACObjects/Corridor.java
@@ -15,6 +15,7 @@ public class Corridor extends Figure {
     public Point start_point, end_point;
     private @Nullable Point center;
     public double width;
+    private static final double DELIMITER_SIZE = 500;
 
     /**
      * Constructeur d'un {@code Corridor}
@@ -74,6 +75,41 @@ public class Corridor extends Figure {
     @Override
     public String toString() {
         return this.name + " " + this.start_point + " " + this.end_point + " " + this.width;
+    }
+
+    /**
+     * Export en KML du {@code Corridor}.
+     * <br>
+     * On génère deux lignes parallèles, orthogonales à la ligne reliant les deux extrémités du {@code Corridor}.
+     * @return le code KML du {@code Corridor}
+     */
+    @Override
+    public String export_kml() {
+        // TODO: prévoir un style propre pour le corridor
+        StringBuilder res = new StringBuilder();
+
+        // on s'assure que les délimiteurs ont une taille fixe
+        final double angular_size = GeomUtils.meter2degree(DELIMITER_SIZE);
+        final double size_coeff = Math.max(angular_size/this.dx(), angular_size/this.dy());
+        // on calcule les deltas de position
+        final double delta_y = size_coeff * this.dy();
+        final double delta_x = size_coeff * this.dx();
+
+        // premier côté
+        Point ps1 = new Point(this.start_point.latitude - delta_y,
+                this.start_point.longitude + delta_x);
+        Point ps2 = new Point(this.start_point.latitude + delta_y,
+                this.start_point.longitude - delta_x);
+        res.append((new Line("corr1", ps1, start_point, ps2)).export_kml());
+
+        // end_point side
+        Point pe1 = new Point(this.end_point.latitude - delta_y,
+                this.end_point.longitude + delta_x);
+        Point pe2 = new Point(this.end_point.latitude + delta_y,
+                this.end_point.longitude - delta_x);
+        res.append((new Line("corr2", pe1, end_point, pe2)).export_kml());
+
+        return res.toString();
     }
 
 }

--- a/src/main/java/com/apogee/dev/CUJaS/SITACObjects/Corridor.java
+++ b/src/main/java/com/apogee/dev/CUJaS/SITACObjects/Corridor.java
@@ -15,7 +15,7 @@ public class Corridor extends Figure {
     public Point start_point, end_point;
     private @Nullable Point center;
     public double width;
-    private static final double DELIMITER_SIZE = 500;
+    private static final double DELIMITER_SIZE = 1000;
 
     /**
      * Constructeur d'un {@code Corridor}

--- a/src/main/java/com/apogee/dev/CUJaS/SITACObjects/Line.java
+++ b/src/main/java/com/apogee/dev/CUJaS/SITACObjects/Line.java
@@ -1,8 +1,10 @@
 package com.apogee.dev.CUJaS.SITACObjects;
 
 import com.apogee.dev.CUJaS.SITACObjects.utils.KMLUtils;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 
 /**
  * Implémentation de la {@code Line}
@@ -19,6 +21,12 @@ public class Line extends Figure {
     public Line(ArrayList<Point> points, String... name) {
         super(name);
         this.points.addAll(points);
+    }
+
+    public Line (@Nullable String name, Point... points) {
+        super(name == null ? "" : name);
+        if (points.length == 0) this.points = new ArrayList<>();
+        this.points.addAll(Arrays.asList(points));
     }
 
     /**
@@ -51,11 +59,10 @@ public class Line extends Figure {
     @Override
     public String export_kml() {
         StringBuilder coords = new StringBuilder();
-        this.points.add(this.points.get(0));
         for (Point p : this.points) {
             coords.append(p.longitude).append(",").append(p.latitude).append(",0 \n");
         }
-        return KMLUtils.kmlPolygon(this.name, "#style_line", coords.toString());
+        return KMLUtils.kmlLine(this.name, "#style_line", coords.toString());
     }
 
 }

--- a/src/main/java/com/apogee/dev/CUJaS/SITACObjects/Polygon.java
+++ b/src/main/java/com/apogee/dev/CUJaS/SITACObjects/Polygon.java
@@ -50,6 +50,8 @@ public class Polygon extends Line {
     @Override
     public String export_kml() {
         StringBuilder coords = new StringBuilder();
+        // on s'assure que le polygone est fermé
+        if (this.points.get(0) != this.points.get(this.points.size() - 1)) this.points.add(this.points.get(0));
         for (Point p : this.points) {
             coords.append(p.longitude).append(",").append(p.latitude).append(",0 \n");
         }

--- a/src/main/java/com/apogee/dev/CUJaS/SITACObjects/utils/KMLUtils.java
+++ b/src/main/java/com/apogee/dev/CUJaS/SITACObjects/utils/KMLUtils.java
@@ -34,6 +34,28 @@ public class KMLUtils {
     }
 
     /**
+     * Génère le KML pour une {@code Line}.
+     * @param name nom de la ligne
+     * @param styleUrl référence vers le style à utiliser
+     * @param coords concaténation des coordonnées des points de la ligne
+     * @return le fragment KML correspondant
+     * @see <a href="https://developers.google.com/kml/documentation/kmlreference#linestring">LineString dans la doc KML</a>
+     * @see <a href="https://developers.google.com/kml/documentation/kml_tut#paths">Définition de Path (doc KML)</a>
+     */
+    public static String kmlLine(String name, String styleUrl, String coords) {
+        return """
+                <Placemark>
+                    <name>%s</name>
+                    <styleUrl>%s</styleUrl>
+                    <LineString>
+                        <coordinates>
+                            %s
+                        </coordinates>
+                    </LineString>
+                  </Placemark>""".formatted(name, styleUrl, coords);
+    }
+
+    /**
      * Génère le fragment KML pour une ligne, sans autre élément de contexte ou style.
      * @param coords concaténation des coordonnées des points de la ligne
      * @return le fragment KML correspondant


### PR DESCRIPTION
1. Export de la porte (`Corridor`) en kml (closes #60, enables closing of #51 upon completion of tasks)
2. Bugfix de l'export de la ligne (closing #63 & #64)